### PR TITLE
Switch resume extraction from Gemini to GitHub Models (free, no API key)

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  models: read
 
 concurrency:
   group: pages
@@ -31,11 +32,10 @@ jobs:
 
       - run: npm ci
 
-      - name: Sync content (GitHub repos + resume via Gemini)
+      - name: Sync content (GitHub repos + resume via GitHub Models)
         run: npm run sync
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Commit updated content
         run: |

--- a/README.md
+++ b/README.md
@@ -6,18 +6,20 @@ Tailwind single-page app, deployed to GitHub Pages.
 ## How content stays fresh
 
 ```
-GitHub repos (topic: portfolio) ─┐
-                                 ├─> scripts/sync.mjs ─> src/content/dynamic.json ─> static build
-public/resume.pdf ── Gemini ─────┘
+GitHub repos (topic: portfolio) ─────────────┐
+                                             ├─> scripts/sync.mjs ─> src/content/dynamic.json ─> static build
+public/resume.pdf ─ unpdf ─ GitHub Models ───┘
 ```
 
 - **Projects** — `scripts/sync.mjs` pulls public repos tagged with the
   `portfolio` topic from the GitHub REST API.
-- **Experience / skills / education / certifications** — the script sends
-  `public/resume.pdf` to Gemini (`gemini-2.5-flash-lite`, temperature 0,
-  strict JSON-only extraction) and validates the result.
+- **Experience / skills / education / certifications** — the script extracts
+  text from `public/resume.pdf` locally (via `unpdf`), then sends that text to
+  GitHub Models (`openai/gpt-4o-mini`, temperature 0, strict JSON-only
+  extraction) and validates the result. No extra API key needed — it
+  authenticates with the built-in `GITHUB_TOKEN`.
 - Results land in `src/content/dynamic.json`, which is committed back and baked
-  into the static build. On any failure (or missing resume / API key) the
+  into the static build. On any failure (or missing resume / token) the
   affected sections keep their previous values — empty data never overwrites
   good data.
 - `.github/workflows/sync.yml` runs this weekly (Sundays 00:00 UTC), on manual
@@ -34,16 +36,18 @@ npm install
 npm run dev      # dev server
 npm run build    # type-check + production build to dist/
 npm run preview  # serve the production build
-npm run sync     # refresh src/content/dynamic.json (GITHUB_TOKEN / GEMINI_API_KEY optional)
+npm run sync     # refresh src/content/dynamic.json (GITHUB_TOKEN enables repo fetch auth + resume extraction)
 ```
 
 ## Setup checklist
 
 1. Tag the repos that should appear on the site with the `portfolio` topic on GitHub.
-2. Add a `GEMINI_API_KEY` repository secret (Google AI Studio free tier works).
-3. Commit your resume as `public/resume.pdf` (see `public/RESUME_PLACEHOLDER.txt`).
-4. Rename this repo to `selleckelliott.github.io`. The Vite base is `/`, so the
+2. Commit your resume as `public/resume.pdf` (see `public/RESUME_PLACEHOLDER.txt`).
+   No API key or secret is needed — resume extraction uses GitHub Models with
+   the workflow's built-in `GITHUB_TOKEN` (the sync workflow grants it
+   `models: read` permission).
+3. Rename this repo to `selleckelliott.github.io`. The Vite base is `/`, so the
    site will not render correctly at `/Personal_Website/` before the rename.
-5. After the first deploy run, confirm Pages is serving from GitHub Actions
+4. After the first deploy run, confirm Pages is serving from GitHub Actions
    (Settings → Pages); `actions/configure-pages` with `enablement: true`
    switches it from the legacy branch build automatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "tailwindcss": "^4.3.0",
         "typescript": "~5.9.3",
+        "unpdf": "^1.6.2",
         "vite": "^8.0.16"
       }
     },
@@ -1318,6 +1319,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.9.3",
+    "unpdf": "^1.6.2",
     "vite": "^8.0.16"
   }
 }

--- a/public/RESUME_PLACEHOLDER.txt
+++ b/public/RESUME_PLACEHOLDER.txt
@@ -1,9 +1,10 @@
 resume.pdf goes here.
 
 Commit your resume as public/resume.pdf (exact name). The sync workflow
-(.github/workflows/sync.yml) detects pushes to that path, sends the PDF to
-Gemini, and updates src/content/dynamic.json (experience, skills, education,
-certifications) — no manual editing needed.
+(.github/workflows/sync.yml) detects pushes to that path, extracts its text,
+sends it to GitHub Models (no API key needed), and updates
+src/content/dynamic.json (experience, skills, education, certifications)
+— no manual editing needed.
 
 Until the file exists:
 - the "Resume" download button on the site will 404 (expected)

--- a/scripts/sync.mjs
+++ b/scripts/sync.mjs
@@ -5,15 +5,16 @@
  * Sources:
  *   1. GitHub REST API — public repos for GITHUB_USER tagged with the
  *      `portfolio` topic (uses GITHUB_TOKEN when present, anonymous otherwise).
- *   2. Gemini — structured extraction of public/resume.pdf into
+ *   2. GitHub Models — structured extraction of text from public/resume.pdf
+ *      (extracted locally via unpdf) into
  *      { experience, skills, education, certifications }.
  *
  * Failure policy: never write empty/broken data over good data. Each section
  * falls back to the existing dynamic.json content if its source is missing,
- * fails, or returns nothing useful. Missing GEMINI_API_KEY or resume.pdf are
+ * fails, or returns nothing useful. Missing GITHUB_TOKEN or resume.pdf are
  * clean skips, not errors. The file is only rewritten when content changed.
  *
- * Requires Node 20+ (native fetch). No runtime dependencies.
+ * Requires Node 20+ (native fetch). Only dev dependency: unpdf (PDF text).
  */
 import { readFile, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
@@ -26,7 +27,9 @@ const RESUME_PATH = path.join(ROOT, 'public', 'resume.pdf')
 
 const GITHUB_USER = 'selleckelliott'
 const PORTFOLIO_TOPIC = 'portfolio'
-const GEMINI_MODEL = 'gemini-2.5-flash-lite'
+const MODELS_URL = 'https://models.github.ai/inference/chat/completions'
+const MODELS_MODEL = 'openai/gpt-4o-mini'
+const MIN_RESUME_TEXT_CHARS = 200
 
 const EMPTY_CONTENT = {
   generatedAt: null,
@@ -37,11 +40,11 @@ const EMPTY_CONTENT = {
   certifications: [],
 }
 
-const EXTRACTION_PROMPT = `You are a strict data-extraction engine. Extract structured resume data from the attached PDF.
+const EXTRACTION_PROMPT = `You are a strict data-extraction engine. Extract structured resume data from the plain text below (extracted from a resume PDF).
 
 Rules:
-- Use ONLY information explicitly present in the PDF. Never infer, embellish, or invent anything.
-- If a field is not present in the PDF, use an empty string "" (or omit the entry entirely).
+- Use ONLY information explicitly present in the text. Never infer, embellish, or invent anything.
+- If a field is not present in the text, use an empty string "" (or omit the entry entirely).
 - Copy bullet points nearly verbatim; you may trim whitespace and trailing punctuation only.
 - Dates as short strings such as "Jan 2023" or "2023"; use "Present" for current roles.
 - Output ONLY valid JSON matching exactly this schema — no markdown, no commentary:
@@ -55,7 +58,10 @@ Rules:
     { "institution": "", "credential": "", "year": "", "details": "" }
   ],
   "certifications": [""]
-}`
+}
+
+Resume text:
+`
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -118,12 +124,12 @@ async function fetchProjects() {
 }
 
 // ---------------------------------------------------------------------------
-// Source 2: Gemini resume extraction
+// Source 2: resume extraction (local PDF text -> GitHub Models)
 // ---------------------------------------------------------------------------
 
 async function extractResume() {
-  if (!process.env.GEMINI_API_KEY) {
-    console.log('- GEMINI_API_KEY not set — skipping resume extraction (keeping existing data).')
+  if (!process.env.GITHUB_TOKEN) {
+    console.log('- GITHUB_TOKEN not set — skipping resume extraction (keeping existing data).')
     return null
   }
   if (!existsSync(RESUME_PATH)) {
@@ -131,39 +137,43 @@ async function extractResume() {
     return null
   }
 
+  // Step a: extract plain text locally — the PDF itself is never uploaded.
+  const { extractText } = await import('unpdf')
   const pdf = await readFile(RESUME_PATH)
-  const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-goog-api-key': process.env.GEMINI_API_KEY,
-      },
-      body: JSON.stringify({
-        contents: [
-          {
-            parts: [
-              { inline_data: { mime_type: 'application/pdf', data: pdf.toString('base64') } },
-              { text: EXTRACTION_PROMPT },
-            ],
-          },
-        ],
-        generationConfig: { temperature: 0, responseMimeType: 'application/json' },
-      }),
+  const { text } = await extractText(new Uint8Array(pdf), { mergePages: true })
+  const resumeText = (text ?? '').trim()
+  if (resumeText.length < MIN_RESUME_TEXT_CHARS) {
+    console.log(
+      `- Resume text too short (${resumeText.length} chars < ${MIN_RESUME_TEXT_CHARS}) — skipping extraction (keeping existing data).`,
+    )
+    return null
+  }
+
+  // Step b: structured extraction via GitHub Models.
+  const res = await fetch(MODELS_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      'X-GitHub-Api-Version': '2022-11-28',
     },
-  )
+    body: JSON.stringify({
+      model: MODELS_MODEL,
+      temperature: 0,
+      response_format: { type: 'json_object' },
+      messages: [{ role: 'user', content: EXTRACTION_PROMPT + resumeText }],
+    }),
+  })
   if (!res.ok) {
-    throw new Error(`Gemini API ${res.status}: ${(await res.text()).slice(0, 300)}`)
+    throw new Error(`GitHub Models API ${res.status}: ${(await res.text()).slice(0, 300)}`)
   }
 
   const data = await res.json()
-  const text = (data?.candidates?.[0]?.content?.parts ?? [])
-    .map((p) => p.text ?? '')
-    .join('')
+  const content = (data?.choices?.[0]?.message?.content ?? '')
     .replace(/^\s*```(?:json)?\s*|\s*```\s*$/g, '')
-  if (!text.trim()) throw new Error('Gemini returned an empty response.')
-  return JSON.parse(text)
+  if (!content.trim()) throw new Error('GitHub Models returned an empty response.')
+  return JSON.parse(content)
 }
 
 /** Validate one extracted section; returns a clean array or null if unusable. */


### PR DESCRIPTION
## Summary

Replaces the Gemini-based resume extraction (merged in #2) with **GitHub Models** — free for public repos, and **no API key or secret to configure**. This change was needed because Google AI Studio is region-blocked for Selleck, so a `GEMINI_API_KEY` could never be provisioned.

### How it works now

1. `scripts/sync.mjs` extracts plain text from `public/resume.pdf` **locally** via [`unpdf`](https://github.com/unjs/unpdf) (new devDependency, no native deps — the PDF itself is never uploaded). If extraction yields under 200 chars, the script skips cleanly and keeps previous data.
2. The extracted text is sent to the GitHub Models REST API (`POST https://models.github.ai/inference/chat/completions`, model `openai/gpt-4o-mini`, temperature 0, `response_format: json_object`) authenticated with the built-in `GITHUB_TOKEN` — same strict JSON-only anti-hallucination prompt, schema validation, and per-section fallback as before (empty/failed results never overwrite good data).

### Changes

- `scripts/sync.mjs` — unpdf text extraction + GitHub Models call; **all `GEMINI_API_KEY` references removed**, `GITHUB_TOKEN` is the only env var
- `.github/workflows/sync.yml` — dropped the `GEMINI_API_KEY` env; added `models: read` to permissions (required for `GITHUB_TOKEN` to call GitHub Models in Actions)
- `README.md` / `public/RESUME_PLACEHOLDER.txt` — setup docs updated: no API-key step anymore

### Verified

- `npm run build` passes
- `npm run sync` exits 0 with clean skips both without `GITHUB_TOKEN` and with a token but no `resume.pdf`
- GitHub Models endpoint smoke-tested with dummy text using the script's exact request shape → HTTP 200 with a valid completion
